### PR TITLE
fix: workers 参数未生效的问题

### DIFF
--- a/docker_image_puller.py
+++ b/docker_image_puller.py
@@ -845,7 +845,8 @@ def download_layers(
     img: str,
     tag: str,
     arch: str,
-    output_dir: Path
+    output_dir: Path,
+    workers: int
 ):
     global progress_display
     progress_display = ProgressDisplay()
@@ -915,7 +916,7 @@ def download_layers(
 
     progress_display.print_initial()
 
-    num_workers = min(len(layers_to_download), 4) if layers_to_download else 1
+    num_workers = min(len(layers_to_download), max(1, workers)) if layers_to_download else 1
 
     with ThreadPoolExecutor(max_workers=num_workers) as executor:
         futures = {}
@@ -1227,7 +1228,7 @@ def main():
             session, image_info.registry, image_info.repository,
             resp_json['layers'], auth_head, imgdir, resp_json,
             imgparts, image_info.image_name, image_info.tag, args.arch,
-            output_dir
+            output_dir, args.workers
         )
 
         output_file = create_image_tar(imgdir, image_info.repository, image_info.tag, args.arch, output_dir)


### PR DESCRIPTION
## 变更说明

修复 CLI 中 `--workers` 参数未实际生效的问题。参数已定义，但下载镜像层时线程池并发数固定为 4。

## 修改内容

- 将 `workers` 参数传入 `download_layers`
- 对 `workers <= 0` 做兜底，至少使用 1 个 worker